### PR TITLE
Исправление для php 8.2+

### DIFF
--- a/src/WebRequest.php
+++ b/src/WebRequest.php
@@ -19,7 +19,7 @@ class WebRequest extends HttpRequest
         $request = self::createFromGlobals($this);
         if (($app = App::instance()) instanceof WebApp) {
             $request->withUri(
-                str_replace($app->uri()->getPath(), '', $request->getUri())
+                str_replace($app->uri()->getPath() ?? '', '', $request->getUri())
             );
             $app::set('request', $this);
         }


### PR DESCRIPTION
Deprecated: str_replace(): Passing null to parameter #1 ($search) of type array|string is deprecated